### PR TITLE
fix: Add warning for recent worst day data (#20)

### DIFF
--- a/frontend/src/components/ui/StatCard.tsx
+++ b/frontend/src/components/ui/StatCard.tsx
@@ -2,6 +2,7 @@ interface StatCardProps {
   label: string
   value: string
   sublabel?: string
+  note?: string
   color?: 'default' | 'success' | 'warning' | 'danger' | 'info'
   loading?: boolean
 }
@@ -10,6 +11,7 @@ export function StatCard({
   label,
   value,
   sublabel,
+  note,
   color = 'default',
   loading = false,
 }: StatCardProps) {
@@ -59,6 +61,7 @@ export function StatCard({
       <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">{label}</p>
       <p className={`mt-1 text-xl font-semibold ${getValueColor()}`}>{value}</p>
       {sublabel && <p className="mt-1 text-xs text-slate-400">{sublabel}</p>}
+      {note && <p className="mt-1 text-xs text-amber-600 italic">{note}</p>}
     </div>
   )
 }

--- a/frontend/src/modules/performance/PerformanceSummary.tsx
+++ b/frontend/src/modules/performance/PerformanceSummary.tsx
@@ -2,7 +2,7 @@ import { Calendar } from 'lucide-react'
 import { StatCard } from '../../components/ui/StatCard'
 import { usePerformance } from '../../hooks/useAnalytics'
 import { formatCurrency, formatCurrencyFull } from '../../lib/chartConfig'
-import { format, parseISO } from 'date-fns'
+import { format, parseISO, differenceInDays } from 'date-fns'
 
 export function PerformanceSummary() {
   const { data, isLoading } = usePerformance()
@@ -12,6 +12,18 @@ export function PerformanceSummary() {
       return format(parseISO(dateStr), 'MMM d')
     } catch {
       return dateStr
+    }
+  }
+
+  // Check if worst day is recent (within 2 days) - may have incomplete data
+  const isWorstDayRecent = () => {
+    if (!data?.trends.worst_day?.date) return false
+    try {
+      const worstDate = parseISO(data.trends.worst_day.date)
+      const daysDiff = differenceInDays(new Date(), worstDate)
+      return daysDiff <= 2
+    } catch {
+      return false
     }
   }
 
@@ -44,6 +56,7 @@ export function PerformanceSummary() {
           label="Worst Day"
           value={data?.trends.worst_day ? formatDate(data.trends.worst_day.date) : '-'}
           sublabel={data?.trends.worst_day ? formatCurrency(data.trends.worst_day.revenue) : undefined}
+          note={isWorstDayRecent() ? 'May have incomplete data' : undefined}
           color="warning"
           loading={isLoading}
         />


### PR DESCRIPTION
When Worst Day is within last 2 days, show 'May have incomplete data' note since recent days often appear as worst performers due to data sync timing.